### PR TITLE
Fix for NS 5.3

### DIFF
--- a/plugin/index.d.ts
+++ b/plugin/index.d.ts
@@ -1,5 +1,5 @@
-import Application = require("application");
-import ImageSource = require('image-source');
+import Application = require("tns-core-modules/application");
+import ImageSource = require('tns-core-modules/image-source');
 /**
  * Describes an object that stores ARGB color data.
  */


### PR DESCRIPTION
As of NS 5.3 need to include full import path to `tns-core-modules`, see [this blog post](https://www.nativescript.org/blog/say-goodbye-to-short-imports-in-nativescript)